### PR TITLE
A round of PNA additions

### DIFF
--- a/PNA.mdk
+++ b/PNA.mdk
@@ -181,11 +181,11 @@ to enable developers to write programs that are portable across
 multiple NIC devices that are conformant to the PNA[^PNAPortability].
 
 [^PNAPortability]: Of course, given the tight hardware resource
-constraints on NIC devices, there is no promise that a given P4
-program that compiles on one device will also compile on another
-device. However, it should at least be the case that those P4 programs
-that are able to compile on multiple NIC devices should process
-packets as described in this document.
+    constraints on NIC devices, there is no promise that a given P4
+    program that compiles on one device will also compile on another
+    device. However, it should at least be the case that those P4
+    programs that are able to compile on multiple NIC devices should
+    process packets as described in this document.
 
 The Portable NIC Architecture (PNA) Model has four programmable P4
 blocks and several fixed-function blocks, as shown in Figure
@@ -374,7 +374,9 @@ the `pna.p4` include file and demonstrate features of PNA. Source code
 for the complete programs can be found in the official repository
 containing the PNA specification[^PNAExamplePrograms].
 
-[^PNAExamplePrograms]: <https://github.com/p4lang/pna> in directory `examples`.  Direct link: <https://github.com/p4lang/pna/tree/master/examples>
+[^PNAExamplePrograms]: <https://github.com/p4lang/pna>
+    in directory `examples`.  Direct link:
+    <https://github.com/p4lang/pna/tree/master/examples>
 
 # Naming conventions
 
@@ -414,13 +416,14 @@ Create another figure with names for the paths.
 
 ## PNA type definitions {#sec-pna-type-definitions}
 
-Each PNA implementation will have specific bit widths for the
-following types in the data plane.  These widths are defined in the
+Each PNA implementation will have specific bit widths in the data
+plane for the types shown in the code excerpt of Section
+[#sec-pna-type-definitions-code].  These widths are defined in the
 target specific `pna.p4` include file.  They are expected to differ
 from one PNA implementation to another[^PNAP4TargetSpecific].
 
 [^PNAP4TargetSpecific]: It is expected that `pna.p4` include files for
-    different targets will typically be nearly identical to each
+    different targets will be nearly identical to each
     other.  Besides the possibility of differing bit widths for these
     PNA types, the only expected differences between `pna.p4` files
     for different targets would be annotations on externs, etc. that
@@ -433,6 +436,21 @@ large as the corresponding `InHeader_t` type below, such that they
 hold a value for any target. All PNA implementations must use data
 plane sizes for these types no wider than the corresponding
 `InHeader_t`-defined types.
+
+[^P4RuntimeAPI]: The P4Runtime Specification can be found here:
+    <https://p4.org/specs>
+
+### PNA port types
+
+There are three types defined by PNA for holding different kinds of
+ports.
+
+
+### PNA type definition code excerpt {#sec-pna-type-definitions-code}
+
+~ Begin P4Example
+[INCLUDE=pna.p4:Type_defns]
+~ End P4Example
 
 ## PNA supported metadata types
 
@@ -590,7 +608,7 @@ the places mentioned in Table [#table-extern-usage].
 |-------------------|----------------------------------------------|
 | `ActionSelector`  | Pre, Main |
 |-------------------|----------------------------------------------|
-| `Checksum`        | PreParser, MainParser, MainDeparser |
+| `Checksum`        | MainParser, MainDeparser |
 |-------------------|----------------------------------------------|
 | `Counter`         | Pre, Main |
 |-------------------|----------------------------------------------|
@@ -602,7 +620,7 @@ the places mentioned in Table [#table-extern-usage].
 |-------------------|----------------------------------------------|
 | `Hash`            | Pre, Main |
 |-------------------|----------------------------------------------|
-| `InternetChecksum` | PreParser, MainParser, MainDeparser |
+| `InternetChecksum` | MainParser, MainDeparser |
 |-------------------|----------------------------------------------|
 | `Meter`           | Pre, Main |
 |-------------------|----------------------------------------------|
@@ -635,34 +653,11 @@ restricted to be within parsers in PNA programs. P4~16~ restricts all
 `verify` method calls to be within parsers for all P4~16~ programs,
 regardless of whether they are for the PNA.
 
-~Begin TBD 
-For the descriptions of each of the externs, simply reference the
-corresponding section of the PSA specification if they are the same
-between PNA and PSA.
-~End TBD
-
-## Hashes {#sec-hash-algorithms}
-
-~Begin TBD
-Probably Toeplitz hash algorithm needs to be added for NICs, since it
-is often used in receive side scaling.
-~End TBD
-
-## Checksums {#sec-checksums}
-
-## Counters
-
-## Meters {#sec-meters}
-
-## Registers {#sec-registers}
-
-## Random
-
-## Action Profile {#sec-action-profile}
-
-## Action Selector {#sec-action-selector}
-
-## Packet Digest {#sec-packet-digest}
+See the PSA specification for definitions of all of these externs.
+There is work under way as of this writing that may result in these
+extern defintions being moved from the PSA specification into a
+separate standard library of P4 extern definitions, and if this is
+done, both the PSA and PNA specifications will reference that.
 
 # PNA Table Properties
 
@@ -675,14 +670,14 @@ specification.
 |-----------------------|------|---------------------------------------|
 | Property name         | Type | See also |
 +:----------------------+:-----+:--------------------------------------+
-| `pna_direct_counter` | one `DirectCounter` instance name | Section [#sec-direct-counter] |
+| `pna_direct_counter` | one `DirectCounter` instance name |  |
 |-----------------------|------|---------------------------------------|
-| `pna_direct_meter` | one `DirectMeter` instance name | Section [#sec-meters] |
+| `pna_direct_meter` | one `DirectMeter` instance name |  |
 |-----------------------|------|---------------------------------------|
-| `pna_implementation`  | instance name of one `ActionProfile` | Sections [#sec-action-profile], [#sec-action-selector] |
+| `pna_implementation`  | instance name of one `ActionProfile` |  |
 |                       | or `ActionSelector` |  |
 |-----------------------|------|---------------------------------------|
-| `pna_empty_group_action` | action | Section [#sec-action-selector] |
+| `pna_empty_group_action` | action |  |
 |-----------------------|------|---------------------------------------|
 | `pna_idle_timeout` | `PNA_IdleTimeout_t` | Section [#sec-idle-timeout] |
 |-----------------------|------|---------------------------------------|

--- a/pna.p4
+++ b/pna.p4
@@ -51,6 +51,7 @@ limitations under the License.
  * as the width of type <name>_t. */
 typedef bit<32> PortIdUint_t;
 typedef bit<32> VportIdUint_t;
+typedef bit<32> InterfaceIdUint_t;
 typedef bit<32> MulticastGroupUint_t;
 typedef bit<16> MirrorSessionIdUint_t;
 typedef bit<8>  MirrorSlotIdUint_t;
@@ -60,6 +61,7 @@ typedef bit<16> MulticastInstanceUint_t;
 typedef bit<64> TimestampUint_t;
 typedef bit<32> FlowIdUint_t;
 typedef bit<8>  ExpireTimeProfileIdUint_t;
+typedef bit<3>  PassNumberUint_t;
 
 typedef bit<32> SecurityAssocIdUint_t;
 
@@ -67,6 +69,8 @@ typedef bit<32> SecurityAssocIdUint_t;
 type PortIdUint_t         PortId_t;
 @p4runtime_translation("p4.org/pna/v1/VportId_t", 32)
 type VportIdUint_t        VportId_t;
+@p4runtime_translation("p4.org/pna/v1/InterfaceId_t", 32)
+type InterfaceIdUint_t    InterfaceId_t;
 @p4runtime_translation("p4.org/pna/v1/MulticastGroup_t", 32)
 type MulticastGroupUint_t MulticastGroup_t;
 @p4runtime_translation("p4.org/pna/v1/MirrorSessionId_t", 16)
@@ -85,13 +89,15 @@ type TimestampUint_t      Timestamp_t;
 type FlowIdUint_t      FlowId_t;
 @p4runtime_translation("p4.org/pna/v1/ExpireTimeProfileId_t", 8)
 type ExpireTimeProfileIdUint_t      ExpireTimeProfileId_t;
+@p4runtime_translation("p4.org/pna/v1/PassNumber_t", 8)
+type PassNumberUint_t      PassNumber_t;
 
 @p4runtime_translation("p4.org/pna/v1/SecurityAssocId_t", 64)
 type SecurityAssocIdUint_t      SecurityAssocId_t;
 
 typedef error   ParserError_t;
 
-const PortId_t PNA_PORT_CPU = (PortId_t) 0xfffffffd;
+const InterfaceId_t PNA_PORT_CPU = (InterfaceId_t) 0xfffffffd;
 
 const MirrorSessionId_t PNA_MIRROR_SESSION_TO_CPU = (MirrorSessionId_t) 0;
 
@@ -116,6 +122,7 @@ const MirrorSessionId_t PNA_MIRROR_SESSION_TO_CPU = (MirrorSessionId_t) 0;
  * as the width of type <name>_t. */
 typedef bit<unspecified> PortIdUint_t;
 typedef bit<unspecified> VportIdUint_t;
+typedef bit<unspecified> InterfaceIdUint_t;
 typedef bit<unspecified> MulticastGroupUint_t;
 typedef bit<unspecified> MirrorSessionIdUint_t;
 typedef bit<unspecified> MirrorSlotIdUint_t;
@@ -125,6 +132,7 @@ typedef bit<unspecified> MulticastInstanceUint_t;
 typedef bit<unspecified> TimestampUint_t;
 typedef bit<unspecified> FlowIdUint_t;
 typedef bit<unspecified> ExpireTimeProfileIdUint_t;
+typedef bit<unspecified> PassNumberUint_t;
 
 typedef bit<unspecified> SecurityAssocIdUint_t;
 
@@ -132,6 +140,8 @@ typedef bit<unspecified> SecurityAssocIdUint_t;
 type PortIdUint_t         PortId_t;
 @p4runtime_translation("p4.org/pna/v1/VportId_t", 32)
 type VportIdUint_t         VportId_t;
+@p4runtime_translation("p4.org/pna/v1/InterfaceId_t", 32)
+type InterfaceIdUint_t     InterfaceId_t;
 @p4runtime_translation("p4.org/pna/v1/MulticastGroup_t", 32)
 type MulticastGroupUint_t MulticastGroup_t;
 @p4runtime_translation("p4.org/pna/v1/MirrorSessionId_t", 16)
@@ -150,13 +160,15 @@ type TimestampUint_t      Timestamp_t;
 type FlowIdUint_t      FlowId_t;
 @p4runtime_translation("p4.org/pna/v1/ExpireTimeProfileId_t", 8)
 type ExpireTimeProfileIdUint_t      ExpireTimeProfileId_t;
+@p4runtime_translation("p4.org/pna/v1/PassNumber_t", 8)
+type PassNumberUint_t      PassNumber_t;
 
 @p4runtime_translation("p4.org/pna/v1/SecurityAssocId_t", 64)
 type SecurityAssocIdUint_t      SecurityAssocId_t;
 
 typedef error   ParserError_t;
 
-const PortId_t PNA_PORT_CPU = (PortId_t) unspecified;
+const InterfaceId_t PNA_PORT_CPU = (PortId_t) unspecified;
 
 const MirrorSessionId_t PNA_MIRROR_SESSION_TO_CPU = (MirrorSessiontId_t) unspecified;
 // END:Type_defns
@@ -191,6 +203,7 @@ const MirrorSessionId_t PNA_MIRROR_SESSION_TO_CPU = (MirrorSessiontId_t) unspeci
  * typedef definitions exist. */
 typedef bit<32> PortIdInHeaderUint_t;
 typedef bit<32> VportIdInHeaderUint_t;
+typedef bit<32> InterfaceIdInHeaderUint_t;
 typedef bit<32> MulticastGroupInHeaderUint_t;
 typedef bit<16> MirrorSessionIdInHeaderUint_t;
 typedef bit<8>  MirrorSlotIdInHeaderUint_t;
@@ -200,6 +213,7 @@ typedef bit<16> MulticastInstanceInHeaderUint_t;
 typedef bit<64> TimestampInHeaderUint_t;
 typedef bit<32> FlowIdInHeaderUint_t;
 typedef bit<8>  ExpireTimeProfileIdInHeaderUint_t;
+typedef bit<8>  PassNumberInHeaderUint_t;
 
 typedef bit<32> SecurityAssocIdInHeaderUint_t;
 
@@ -207,6 +221,8 @@ typedef bit<32> SecurityAssocIdInHeaderUint_t;
 type  PortIdInHeaderUint_t         PortIdInHeader_t;
 @p4runtime_translation("p4.org/pna/v1/VportIdInHeader_t", 32)
 type  VportIdInHeaderUint_t         VportIdInHeader_t;
+@p4runtime_translation("p4.org/pna/v1/InterfaceIdInHeader_t", 32)
+type  InterfaceIdInHeaderUint_t     InterfaceIdInHeader_t;
 @p4runtime_translation("p4.org/pna/v1/MulticastGroupInHeader_t", 32)
 type  MulticastGroupInHeaderUint_t MulticastGroupInHeader_t;
 @p4runtime_translation("p4.org/pna/v1/MirrorSessionIdInHeader_t", 16)
@@ -225,6 +241,8 @@ type  TimestampInHeaderUint_t      TimestampInHeader_t;
 type  FlowIdInHeaderUint_t      FlowIdInHeader_t;
 @p4runtime_translation("p4.org/pna/v1/ExpireTimeProfileIdInHeader_t", 8)
 type  ExpireTimeProfileIdInHeaderUint_t      ExpireTimeProfileIdInHeader_t;
+@p4runtime_translation("p4.org/pna/v1/PassNumberInHeader_t", 8)
+type  PassNumberInHeaderUint_t      PassNumberInHeader_t;
 
 @p4runtime_translation("p4.org/pna/v1/SecurityAssocIdInHeader_t", 64)
 type  SecurityAssocIdInHeaderUint_t      SecurityAssocIdInHeader_t;
@@ -253,6 +271,12 @@ type  SecurityAssocIdInHeaderUint_t      SecurityAssocIdInHeader_t;
 PortId_t pna_PortId_header_to_int (in PortIdInHeader_t x) {
     return (PortId_t) (PortIdUint_t) (PortIdInHeaderUint_t) x;
 }
+VportId_t pna_VportId_header_to_int (in VportIdInHeader_t x) {
+    return (VportId_t) (VportIdUint_t) (VportIdInHeaderUint_t) x;
+}
+InterfaceId_t pna_InterfaceId_header_to_int (in InterfaceIdInHeader_t x) {
+    return (InterfaceId_t) (InterfaceIdUint_t) (InterfaceIdInHeaderUint_t) x;
+}
 MulticastGroup_t pna_MulticastGroup_header_to_int (in MulticastGroupInHeader_t x) {
     return (MulticastGroup_t) (MulticastGroupUint_t) (MulticastGroupInHeaderUint_t) x;
 }
@@ -277,9 +301,18 @@ FlowId_t pna_FlowId_header_to_int (in FlowIdInHeader_t x) {
 ExpireTimeProfileId_t pna_ExpireTimeProfileId_header_to_int (in ExpireTimeProfileIdInHeader_t x) {
     return (ExpireTimeProfileId_t) (ExpireTimeProfileIdUint_t) (ExpireTimeProfileIdInHeaderUint_t) x;
 }
+PassNumber_t pna_PassNumber_header_to_int (in PassNumberInHeader_t x) {
+    return (PassNumber_t) (PassNumberUint_t) (PassNumberInHeaderUint_t) x;
+}
 
 PortIdInHeader_t pna_PortId_int_to_header (in PortId_t x) {
     return (PortIdInHeader_t) (PortIdInHeaderUint_t) (PortIdUint_t) x;
+}
+VportIdInHeader_t pna_VportId_int_to_header (in VportId_t x) {
+    return (VportIdInHeader_t) (VportIdInHeaderUint_t) (VportIdUint_t) x;
+}
+InterfaceIdInHeader_t pna_InterfaceId_int_to_header (in InterfaceId_t x) {
+    return (InterfaceIdInHeader_t) (InterfaceIdInHeaderUint_t) (InterfaceIdUint_t) x;
 }
 MulticastGroupInHeader_t pna_MulticastGroup_int_to_header (in MulticastGroup_t x) {
     return (MulticastGroupInHeader_t) (MulticastGroupInHeaderUint_t) (MulticastGroupUint_t) x;
@@ -304,6 +337,9 @@ FlowIdInHeader_t pna_FlowId_int_to_header (in FlowId_t x) {
 }
 ExpireTimeProfileIdInHeader_t pna_ExpireTimeProfileId_int_to_header (in ExpireTimeProfileId_t x) {
     return (ExpireTimeProfileIdInHeader_t) (ExpireTimeProfileIdInHeaderUint_t) (ExpireTimeProfileIdUint_t) x;
+}
+PassNumberInHeader_t pna_PassNumber_int_to_header (in PassNumber_t x) {
+    return (PassNumberInHeader_t) (PassNumberInHeaderUint_t) (PassNumberUint_t) x;
 }
 
 /// Supported range of values for the pna_idle_timeout table properties
@@ -529,27 +565,16 @@ enum PNA_Direction_t {
 }
 
 // BEGIN:Metadata_types
-enum PNA_PacketPath_t {
-    // TBD if this type remains, whether it should be an enum or
-    // several separate fields representing the same cases in a
-    // different form.
-    FROM_NET_PORT,
-    FROM_NET_LOOPEDBACK,
-    FROM_NET_RECIRCULATED,
-    FROM_HOST,
-    FROM_HOST_LOOPEDBACK,
-    FROM_HOST_RECIRCULATED
-}
-
 struct pna_pre_parser_input_metadata_t {
     PortId_t                 input_port;
-    PNA_PacketPath_t         packet_path;
 }
 
 struct pna_pre_input_metadata_t {
     PortId_t                 input_port;
-    PNA_PacketPath_t         packet_path;
     ParserError_t            parser_error;
+    PNA_Direction_t          direction;
+    PassNumber_t             pass;
+    bool                     loopedback;
 }
 
 struct pna_pre_output_metadata_t {
@@ -577,36 +602,38 @@ struct pna_decrypt_input_metadata_t {
 }
 
 struct pna_main_parser_input_metadata_t {
-  // common fields initialized for all packets that are input to main
-  // parser, regardless of direction.
-  PNA_Direction_t          direction;
-  PNA_PacketPath_t         packet_path;
+    // common fields initialized for all packets that are input to main
+    // parser, regardless of direction.
+    PNA_Direction_t          direction;
+    PassNumber_t             pass;
+    bool                     loopedback;
 
-  // input fields to main parser that are only initialized if
-  // direction == NET_TO_HOST
-  PortId_t                 input_port;
+    // input fields to main parser that are only initialized if
+    // direction == NET_TO_HOST
+    PortId_t                 input_port;   // network port id
 
-  // input fields to main parser that are only initialized if
-  // direction == HOST_TO_NET
-  VportId_t                input_vport;
+    // input fields to main parser that are only initialized if
+    // direction == HOST_TO_NET
+    VportId_t                input_vport;
 }
 
 struct pna_main_input_metadata_t {
-  // common fields initialized for all packets that are input to main
-  // parser, regardless of direction.
-  PNA_Direction_t          direction;
-  PNA_PacketPath_t         packet_path;
-  Timestamp_t              timestamp;
-  ParserError_t            parser_error;
-  ClassOfService_t         class_of_service;
+    // common fields initialized for all packets that are input to main
+    // parser, regardless of direction.
+    PNA_Direction_t          direction;
+    PassNumber_t             pass;
+    bool                     loopedback;
+    Timestamp_t              timestamp;
+    ParserError_t            parser_error;
+    ClassOfService_t         class_of_service;
 
-  // input fields to main control that are only initialized if
-  // direction == NET_TO_HOST
-  PortId_t                 input_port;
+    // input fields to main control that are only initialized if
+    // direction == NET_TO_HOST
+    PortId_t                 input_port;
 
-  // input fields to main control that are only initialized if
-  // direction == HOST_TO_NET
-  VportId_t                input_vport;
+    // input fields to main control that are only initialized if
+    // direction == HOST_TO_NET
+    VportId_t                input_vport;
 }
 
 // BEGIN:Metadata_main_output
@@ -942,13 +969,13 @@ control PreControlT<PH, PM>(
 
 parser MainParserT<PM, MH, MM>(
     packet_in pkt,
-    in    PM pre_user_meta,
+    //in    PM pre_user_meta,
     out   MH main_hdr,
     inout MM main_user_meta,
     in    pna_main_parser_input_metadata_t istd);
 
 control MainControlT<PM, MH, MM>(
-    in    PM pre_user_meta,
+    //in    PM pre_user_meta,
     inout MH main_hdr,
     inout MM main_user_meta,
     in    pna_main_input_metadata_t  istd,
@@ -964,12 +991,13 @@ package PNA_NIC<PH, PM, MH, MM>(
     PreControlT<PH, PM> pre_control,
     MainParserT<PM, MH, MM> main_parser,
     MainControlT<PM, MH, MM> main_control,
-    MainDeparserT<MH, MM> main_deparser,
+    MainDeparserT<MH, MM> main_deparser
     // pre_parser is optional.  If not specified, it defaults to be the
     // same as main_parser.  An implementation that has a separate pre
     // parser is free to optimize away any part of it that is
     // unnecessary for executing the code in pre_control.
-    PreParserT<PH, PM> pre_parser);
+    //, PreParserT<PH, PM> pre_parser
+    );
 // END:Programmable_blocks
 
 #endif   // __PNA_P4__


### PR DESCRIPTION
Start section "PNA port types".  Add types InterfaceId_t and
PassNumber_t.  Remove type PacketPath_t in favor of standard metadata
fields direction, pass, and loopedback.

Remove mentions of pre-parser from spec -- may be added in again later
when we have clear ways of describing how it can be specified, and how
that changes P4 program behavior.

Correct Madoko markup for some footnotes.