### PR TITLE
Remove send_to_vport() from remaining example programs

### DIFF
--- a/examples/pna-demo-L2-one-table.p4
+++ b/examples/pna-demo-L2-one-table.p4
@@ -79,12 +79,9 @@ control MainControlImpl(
     action L2_send_to_port (PortId_t port_id) {
         send_to_port(port_id);
     }
-    action L2_send_to_vport (VportId_t vport_id) {
-        send_to_vport(vport_id);
-    }
     table L2_fwd {
         key = { hdr.eth.dstAddr: exact; }
-        actions = { L2_send_to_port; L2_send_to_vport; drop; }
+        actions = { L2_send_to_port; drop; }
         default_action = drop;
     }
     apply {

--- a/examples/pna-demo-L2-two-tables.p4
+++ b/examples/pna-demo-L2-two-tables.p4
@@ -79,9 +79,6 @@ control MainControlImpl(
     action L2_send_to_port (PortId_t port_id) {
         send_to_port(port_id);
     }
-    action L2_send_to_vport (VportId_t vport_id) {
-        send_to_vport(vport_id);
-    }
 
     // In this demo program, I have chosen to use the same action
     // names for both of the following tables.  In a similar but
@@ -90,12 +87,12 @@ control MainControlImpl(
 
     table L2_fwd_n2h {
         key = { hdr.eth.dstAddr: exact; }
-        actions = { L2_send_to_port; L2_send_to_vport; drop; }
+        actions = { L2_send_to_port; drop; }
         default_action = drop;
     }
     table L2_fwd_h2n {
         key = { hdr.eth.dstAddr: exact; }
-        actions = { L2_send_to_port; L2_send_to_vport; drop; }
+        actions = { L2_send_to_port; drop; }
         default_action = drop;
     }
     apply {

--- a/examples/pna-demo-last-forwarding-action-wins.p4
+++ b/examples/pna-demo-last-forwarding-action-wins.p4
@@ -25,7 +25,6 @@ limitations under the License.
 // effect on the packet.
 
 // + sent_to_port
-// + send_to_vport
 // + drop_packet
 
 
@@ -85,9 +84,6 @@ control MainControlImpl(
     action my_send_to_port (PortId_t port_id) {
         send_to_port(port_id);
     }
-    action my_send_to_vport (VportId_t vport_id) {
-        send_to_vport(vport_id);
-    }
     action my_mirror0 (MirrorSessionId_t mirror_session_id) {
         // "mirror" and "clone" are synonyms.  No difference is
         // implied anywhere in the PNA spec between these two terms.
@@ -122,17 +118,17 @@ control MainControlImpl(
     }
     table t1_rx {
         key = { hdr.eth.srcAddr: exact; }
-        actions = { my_send_to_port; my_send_to_vport; my_drop; NoAction; }
+        actions = { my_send_to_port; my_drop; NoAction; }
         default_action = NoAction;
     }
     table t2_rx {
         key = { hdr.eth.dstAddr: exact; }
-        actions = { my_send_to_port; my_send_to_vport; my_drop; NoAction; }
+        actions = { my_send_to_port; my_drop; NoAction; }
         default_action = NoAction;
     }
     table t3_rx {
         key = { hdr.eth.etherType: exact; }
-        actions = { my_send_to_port; my_send_to_vport; my_drop; NoAction; }
+        actions = { my_send_to_port; my_drop; NoAction; }
         default_action = NoAction;
     }
     table mirror_decision_near_host_rx {

--- a/examples/pna-example-template.p4
+++ b/examples/pna-example-template.p4
@@ -135,9 +135,9 @@ control MainControlImpl(
     DirectCounter<PacketByteCounter_t>(PNA_CounterType_t.PACKETS_AND_BYTES)
         per_prefix_pkt_byte_count;
 
-    action next_hop(VportId_t vport) {
+    action next_hop(PortId_t port) {
         per_prefix_pkt_byte_count.count();
-        send_to_vport(vport);
+        send_to_port(port);
     }
     action default_route_drop() {
         per_prefix_pkt_byte_count.count();

--- a/pna.p4
+++ b/pna.p4
@@ -623,6 +623,7 @@ struct pna_main_output_metadata_t {
   // common fields used by the architecture to decide what to do with
   // the packet next, after the main parser, control, and deparser
   // have finished executing one pass, regardless of the direction.
+  PortId_t                 egress_port;
   ClassOfService_t         class_of_service; // 0
 }
 // END:Metadata_main_output


### PR DESCRIPTION
send_to_vport() extern function was removed a while ago, but was not
removed from all example programs at that time.  Catching up with that
months-old change in the examples with this commit.