### PR TITLE
Use 'git commit --amend' in madoko build script

### DIFF
--- a/.github/workflows/madoko-build.yml
+++ b/.github/workflows/madoko-build.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Commit changes
       run: |
-        git commit -m "docs for ${{ steps.vars.outputs.sha_short }}" docs/PNA-working-draft.{html,pdf}
+        git commit --amend -m "docs for ${{ steps.vars.outputs.sha_short }}" docs/PNA-working-draft.{html,pdf}
 
     - name: Push commit to gh-pages branch
       run: git push -f origin gh-pages


### PR DESCRIPTION
This should reduce the amount of growth in the repo commit history, by only keeping the latest auto-generated version of the PDF and HTML files.