### PR TITLE
Add hash algorithms to pna.p4

### DIFF
--- a/pna.p4
+++ b/pna.p4
@@ -343,7 +343,13 @@ match_kind {
 
 // BEGIN:Hash_algorithms
 enum PNA_HashAlgorithm_t {
-  // TBD what this type's values will be for PNA
+  IDENTITY,
+  CRC32,
+  CRC32_CUSTOM,
+  CRC16,
+  CRC16_CUSTOM,
+  ONES_COMPLEMENT16,  /// One's complement 16-bit sum used for IPv4 headers,
+                      /// TCP, and UDP.
   TARGET_DEFAULT      /// target implementation defined
 }
 // END:Hash_algorithms


### PR DESCRIPTION
Currently hash algorithms are TODO in PNA specification. This PR attempts to complete the TODO and also add defines to use as a flag to hash api to use hash on only source, destination, or both IP/IPv6 addresses, and protocol.

One has to start somewhere and thus psa.p4 hash algorithms have been copied to pna.p4. Also, none of the hash algorithms look like one a Nic can't support.