### PR TITLE
Add @noWarn("unused") on Counter and DirectCounter

### DIFF
--- a/pna.p4
+++ b/pna.p4
@@ -443,6 +443,7 @@ enum PNA_CounterType_t {
 /// Indirect counter with n_counters independent counter values, where
 /// every counter value has a data plane size specified by type W.
 
+@noWarn("unused")
 extern Counter<W, S> {
   Counter(bit<32> n_counters, PNA_CounterType_t type);
   void count(in S index);
@@ -450,6 +451,7 @@ extern Counter<W, S> {
 // END:Counter_extern
 
 // BEGIN:DirectCounter_extern
+@noWarn("unused")
 extern DirectCounter<W> {
   DirectCounter(PNA_CounterType_t type);
   void count();


### PR DESCRIPTION
Just like how psa.p4 has @noWarn("unused") on these two externs because of the unused type parameters, the official pna.p4 should have them too.

Signed-off-by: Andrew Pinski <apinski@marvell.com>