### PR TITLE
Issue #89: Description of Extern Objects for Inline Accelerators

### DIFF
--- a/PNA.mdk
+++ b/PNA.mdk
@@ -864,15 +864,21 @@ done, both the PSA and PNA specifications will reference that.
 
 A variety of inline accelerators can be present on a PNA target. These
 accelerators perform specific functions on a packet. These functions are
-typically implemented in hardware.
+typically implemented in hardware. These accelerators perform specific
+functions on a packet after the deparser has finished executing.
 
 These hardware functions are represented as extern objects in a P4 program.
 An extern object representing a specific accelerator E.g. AES-GCM crypto
-accelerator, can be instantiated in P4 program. The methods defined by
-the extern object are used to control the behavior of the inline accelator
-it represents. This section provides one example definition of a crypto
-acceleration engine. Other extern objects can be defined based on the
-functionality provided by the hardware accelerators.
+accelerator, can be instantiated in a P4 program. The methods defined by
+the extern object are used to send and receive information to/from the
+inline accelerator. Since the accelerators are present after the deparser,
+the information sent to the accelerator takes effect only when packet reaches
+the accelerator. Similarly any information received from accelerator is
+for the previous function performed on the packet.
+
+This section provides one example definition of a crypto acceleration engine.
+Other extern objects can be defined in future based on the functionality
+provided by the hardware accelerators.
 
 ~Begin P4Example
 [INCLUDE=examples/include/crypto-accel.p4:Crypto_accelerator_extern_object]

--- a/PNA.mdk
+++ b/PNA.mdk
@@ -860,6 +860,24 @@ extern definitions being moved from the PSA specification into a
 separate standard library of P4 extern definitions, and if this is
 done, both the PSA and PNA specifications will reference that.
 
+## Extern Objects for Inline Accelerators {#sec-extern-restrictions}
+
+A variety of inline accelerators can be present on a PNA target. These
+accelerators perform specific functions on a packet. These functions are
+typically implemented in hardware.
+
+These hardware functions are represented as extern objects in a P4 program.
+An extern object representing a specific accelerator E.g. AES-GCM crypto
+accelerator, can be instantiated in P4 program. The methods defined by
+the extern object are used to control the behavior of the inline accelator
+it represents. This section provides one example definition of a crypto
+acceleration engine. Other extern objects can be defined based on the
+functionality provided by the hardware accelerators.
+
+~Begin P4Example
+[INCLUDE=examples/include/crypto-accel.p4:Crypto_accelerator_extern_object]
+~End P4Example
+
 # PNA Table Properties
 
 Table [#table-table-properties] lists all P4 table properties defined

--- a/examples/include/crypto-accelerator.p4
+++ b/examples/include/crypto-accelerator.p4
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/// Crypto accelerator Extern definition
+// BEGIN:Crypto_accelerator_extern_object
 
 /// Crypto accelerator object is instantiated for each crypto algorithm
 enum crypto_algorithm_e {
@@ -129,3 +129,4 @@ extern crypto_accelerator {
     // get results of the previous operation
     crypto_results_e get_results();
 }
+// END:Crypto_accelerator_extern_object

--- a/examples/include/crypto-accelerator.p4
+++ b/examples/include/crypto-accelerator.p4
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// BEGIN:Crypto_accelerator_extern_object
-
 /// Crypto accelerator object is instantiated for each crypto algorithm
 enum crypto_algorithm_e {
     AES_GCM
@@ -80,6 +78,9 @@ enum crypto_results_e {
 ///     +------------------+--  ----------------------+-----------+-----+
 ///     Results: Success, Auth Failure, Hardware Error
 ///
+
+// BEGIN:Crypto_accelerator_extern_object
+
 extern crypto_accelerator {
     /// constructor
     /// Some methods provided in this object may be specific to an algorithm used.


### PR DESCRIPTION
@jafingerhut @thomascalvert-xlnx @mariobaldi 
Since extern objects is one of the ways to represent inline accelerators.. I have added it as an example in the spec.
Let me know if you had something else in mind.

I have *not* done the preview of the .mdk changes.. hopefully they are ok.. I'll work on that while you review the text.