### PR TITLE
send_to_port and mirror_packet arguments should be in direction

### DIFF
--- a/PNA.mdk
+++ b/PNA.mdk
@@ -574,7 +574,7 @@ each occurs.
 ### Extern function `send_to_port`
 
 ~ Begin P4Example
-extern void send_to_port(PortId_t dest_port);
+extern void send_to_port(in PortId_t dest_port);
 ~ End P4Example
 
 The extern function `send_to_port` is used to direct a packet to a
@@ -597,8 +597,8 @@ without being looped back.
 ## Packet Mirroring
 
 ~ Begin P4Example
-extern void mirror_packet(MirrorSlotId_t mirror_slot_id,
-                          MirrorSessionId_t mirror_session_id);
+extern void mirror_packet(in MirrorSlotId_t mirror_slot_id,
+                          in MirrorSessionId_t mirror_session_id);
 ~ End P4Example
 
 The extern function `mirror_packet` is used to cause a mirror copy of

--- a/pna.p4
+++ b/pna.p4
@@ -606,10 +606,10 @@ struct pna_main_output_metadata_t {
 
 extern void drop_packet();
 
-extern void send_to_port(PortId_t dest_port);
+extern void send_to_port(in PortId_t dest_port);
 
-extern void mirror_packet(MirrorSlotId_t mirror_slot_id,
-                          MirrorSessionId_t mirror_session_id);
+extern void mirror_packet(in MirrorSlotId_t mirror_slot_id,
+                          in MirrorSessionId_t mirror_session_id);
 
 // TBD: Does it make sense to have a data plane add of a hit action
 // that has in, out, or inout parameters?


### PR DESCRIPTION
I noticed this while testing a front-end change for compile time known-constants fix.
These arguments should not be directionless and not required to be a compile time known constants.

Signed-off-by: Andrew Pinski <apinski@marvell.com>