### PR TITLE
Move setup instructions later in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,10 @@ commit to this repository), can be found on the P4.org specifications
 page [here](https://p4.org/specs).
 
 
-## Setup instructions
-
-See the
-[README](https://github.com/p4lang/p4-spec/blob/master/p4-16/spec/README.md)
-for the P4_16 language specification for instructions on installing
-software that enables you to produce HTML and PDF versions of the PNA
-specification from its Madoko source file.
-
-
 ## Meetings to discuss changes to this specification
 
 P4.org architecture work group meetings are held on most Mondays as
-of 2022.  See the calendar on the [P4.org Working Groups
+of 2022-2023.  See the calendar on the [P4.org Working Groups
 page](https://p4.org/working-groups/) for dates, times, and
 instructions for joining the meetings.
 
@@ -57,6 +48,15 @@ In particular, the `meeting-recordings` sub-folder there contains
 recordings of some recent meetings.  Here is a direct link to that
 sub-folder: [meeting-recordings Google Drive
 folder](https://drive.google.com/drive/folders/1I9gp7Wj4Fh-8ctpchldwXidRRwRbJLfp)
+
+
+## Setup instructions for building specification from source
+
+See the
+[README](https://github.com/p4lang/p4-spec/blob/master/p4-16/spec/README.md)
+for the P4_16 language specification for instructions on installing
+software that enables you to produce HTML and PDF versions of the PNA
+specification from its Madoko source file.
 
 
 ## Spec release process


### PR DESCRIPTION
to make other info that readers probably want to access more often come earlier in the document.